### PR TITLE
Fixed issues #83 and #85

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion flutter.compileSdkVersion
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
@@ -35,8 +35,8 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.example"
-        minSdkVersion 16
-        targetSdkVersion 30
+        minSdkVersion flutter.minSdkVersion
+        targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.6.10'
     repositories {
         google()
         jcenter()

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -6,8 +6,8 @@ import 'package:liquid_swipe/liquid_swipe.dart';
 void main() {
   /// Comment or uncomment to run both examples
   runApp(
-    WithBuilder(),
-    //WithPages()
+      WithBuilder()
+      // WithPages()
   );
 }
 
@@ -30,8 +30,8 @@ class WithBuilder extends StatefulWidget {
 
 class _WithBuilder extends State<WithBuilder> {
   int page = 0;
-  LiquidController liquidController;
-  UpdateType updateType;
+  late LiquidController liquidController;
+  late UpdateType updateType;
 
   List<ItemData> data = [
     ItemData(Colors.blue, "assets/1.png", "Hi", "It's Me", "Sahdeep"),
@@ -40,6 +40,8 @@ class _WithBuilder extends State<WithBuilder> {
     ItemData(Colors.green, "assets/1.png", "Liked?", "Fork!", "Give Star!"),
     ItemData(Colors.yellow, "assets/1.png", "Can be", "Used for",
         "Onboarding design"),
+    ItemData(
+        Colors.pink, "assets/1.png", "Example", "of a page", "with Gesture"),
     ItemData(Colors.red, "assets/1.png", "Do", "try it", "Thank you"),
   ];
 
@@ -91,12 +93,19 @@ class _WithBuilder extends State<WithBuilder> {
                     children: <Widget>[
                       Image.asset(
                         data[index].image,
-                        height: 400,
+                        height: 300,
                         fit: BoxFit.contain,
                       ),
                       Padding(
-                        padding: EdgeInsets.all(20.0),
+                        padding: EdgeInsets.all(index != 4 ? 24.0 : 0),
                       ),
+                      index == 4
+                          ? Padding(
+                              padding:
+                                  const EdgeInsets.symmetric(horizontal: 70.0),
+                              child: ExampleSlider(),
+                            )
+                          : SizedBox.shrink(),
                       Column(
                         children: <Widget>[
                           Text(
@@ -124,6 +133,7 @@ class _WithBuilder extends State<WithBuilder> {
               liquidController: liquidController,
               fullTransitionValue: 880,
               enableSideReveal: true,
+              preferDragFromRevealedArea: true,
               enableLoop: true,
               ignoreUserGestureWhileAnimating: true,
             ),
@@ -143,13 +153,15 @@ class _WithBuilder extends State<WithBuilder> {
               alignment: Alignment.bottomRight,
               child: Padding(
                 padding: const EdgeInsets.all(25.0),
-                child: FlatButton(
+                child: TextButton(
                   onPressed: () {
                     liquidController.animateToPage(
                         page: data.length - 1, duration: 700);
                   },
                   child: Text("Skip to End"),
-                  color: Colors.white.withOpacity(0.01),
+                  style: TextButton.styleFrom(
+                      backgroundColor: Colors.white.withOpacity(0.01),
+                      foregroundColor: Colors.black),
                 ),
               ),
             ),
@@ -157,7 +169,7 @@ class _WithBuilder extends State<WithBuilder> {
               alignment: Alignment.bottomLeft,
               child: Padding(
                 padding: const EdgeInsets.all(25.0),
-                child: FlatButton(
+                child: TextButton(
                   onPressed: () {
                     liquidController.jumpToPage(
                         page: liquidController.currentPage + 1 > data.length - 1
@@ -165,7 +177,9 @@ class _WithBuilder extends State<WithBuilder> {
                             : liquidController.currentPage + 1);
                   },
                   child: Text("Next"),
-                  color: Colors.white.withOpacity(0.01),
+                  style: TextButton.styleFrom(
+                      backgroundColor: Colors.white.withOpacity(0.01),
+                      foregroundColor: Colors.black),
                 ),
               ),
             )
@@ -196,18 +210,11 @@ class WithPages extends StatefulWidget {
 
 class _WithPages extends State<WithPages> {
   int page = 0;
-  LiquidController liquidController;
-  UpdateType updateType;
-
-  @override
-  void initState() {
-    liquidController = LiquidController();
-    super.initState();
-  }
-
+  late LiquidController liquidController;
+  late UpdateType updateType;
   final pages = [
     Container(
-      color: Colors.pink,
+      color: Colors.blue,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.center,
         mainAxisSize: MainAxisSize.max,
@@ -218,7 +225,7 @@ class _WithPages extends State<WithPages> {
             fit: BoxFit.cover,
           ),
           Padding(
-            padding: EdgeInsets.all(20.0),
+            padding: EdgeInsets.all(24.0),
           ),
           Column(
             children: <Widget>[
@@ -251,7 +258,7 @@ class _WithPages extends State<WithPages> {
             fit: BoxFit.cover,
           ),
           Padding(
-            padding: EdgeInsets.all(20.0),
+            padding: EdgeInsets.all(24.0),
           ),
           Column(
             children: <Widget>[
@@ -273,7 +280,7 @@ class _WithPages extends State<WithPages> {
       ),
     ),
     Container(
-      color: Colors.greenAccent,
+      color: Colors.green,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.center,
         mainAxisSize: MainAxisSize.max,
@@ -284,7 +291,7 @@ class _WithPages extends State<WithPages> {
             fit: BoxFit.cover,
           ),
           Padding(
-            padding: EdgeInsets.all(20.0),
+            padding: EdgeInsets.all(24.0),
           ),
           Column(
             children: <Widget>[
@@ -306,7 +313,7 @@ class _WithPages extends State<WithPages> {
       ),
     ),
     Container(
-      color: Colors.yellowAccent,
+      color: Colors.yellow,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.center,
         mainAxisSize: MainAxisSize.max,
@@ -317,7 +324,7 @@ class _WithPages extends State<WithPages> {
             fit: BoxFit.cover,
           ),
           Padding(
-            padding: EdgeInsets.all(20.0),
+            padding: EdgeInsets.all(24.0),
           ),
           Column(
             children: <Widget>[
@@ -339,7 +346,7 @@ class _WithPages extends State<WithPages> {
       ),
     ),
     Container(
-      color: Colors.redAccent,
+      color: Colors.pink,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.center,
         mainAxisSize: MainAxisSize.max,
@@ -350,7 +357,41 @@ class _WithPages extends State<WithPages> {
             fit: BoxFit.cover,
           ),
           Padding(
-            padding: EdgeInsets.all(20.0),
+            padding: const EdgeInsets.symmetric(horizontal: 70.0),
+            child: ExampleSlider(),
+          ),
+          Column(
+            children: <Widget>[
+              Text(
+                "Example",
+                style: WithPages.style,
+              ),
+              Text(
+                "of a page",
+                style: WithPages.style,
+              ),
+              Text(
+                "with Gesture",
+                style: WithPages.style,
+              ),
+            ],
+          ),
+        ],
+      ),
+    ),
+    Container(
+      color: Colors.red,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        mainAxisSize: MainAxisSize.max,
+        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+        children: <Widget>[
+          Image.asset(
+            'assets/1.png',
+            fit: BoxFit.cover,
+          ),
+          Padding(
+            padding: EdgeInsets.all(24.0),
           ),
           Column(
             children: <Widget>[
@@ -372,6 +413,12 @@ class _WithPages extends State<WithPages> {
       ),
     ),
   ];
+
+  @override
+  void initState() {
+    liquidController = LiquidController();
+    super.initState();
+  }
 
   Widget _buildDot(int index) {
     double selectedness = Curves.easeOut.transform(
@@ -404,12 +451,16 @@ class _WithPages extends State<WithPages> {
           children: <Widget>[
             LiquidSwipe(
               pages: pages,
+              positionSlideIcon: 0.8,
+              fullTransitionValue: 880,
               slideIconWidget: Icon(Icons.arrow_back_ios),
               onPageChangeCallback: pageChangeCallback,
               waveType: WaveType.liquidReveal,
               liquidController: liquidController,
+              preferDragFromRevealedArea: true,
               enableSideReveal: true,
               ignoreUserGestureWhileAnimating: true,
+              enableLoop: true,
             ),
             Padding(
               padding: EdgeInsets.all(20),
@@ -427,13 +478,15 @@ class _WithPages extends State<WithPages> {
               alignment: Alignment.bottomRight,
               child: Padding(
                 padding: const EdgeInsets.all(25.0),
-                child: FlatButton(
+                child: TextButton(
                   onPressed: () {
                     liquidController.animateToPage(
                         page: pages.length - 1, duration: 700);
                   },
                   child: Text("Skip to End"),
-                  color: Colors.white.withOpacity(0.01),
+                  style: TextButton.styleFrom(
+                      backgroundColor: Colors.white.withOpacity(0.01),
+                      foregroundColor: Colors.black),
                 ),
               ),
             ),
@@ -441,7 +494,7 @@ class _WithPages extends State<WithPages> {
               alignment: Alignment.bottomLeft,
               child: Padding(
                 padding: const EdgeInsets.all(25.0),
-                child: FlatButton(
+                child: TextButton(
                   onPressed: () {
                     liquidController.jumpToPage(
                         page:
@@ -450,7 +503,9 @@ class _WithPages extends State<WithPages> {
                                 : liquidController.currentPage + 1);
                   },
                   child: Text("Next"),
-                  color: Colors.white.withOpacity(0.01),
+                  style: TextButton.styleFrom(
+                      backgroundColor: Colors.white.withOpacity(0.01),
+                      foregroundColor: Colors.black),
                 ),
               ),
             )
@@ -464,5 +519,29 @@ class _WithPages extends State<WithPages> {
     setState(() {
       page = lpage;
     });
+  }
+}
+
+class ExampleSlider extends StatefulWidget {
+  const ExampleSlider({Key? key}) : super(key: key);
+
+  @override
+  State<ExampleSlider> createState() => _ExampleSliderState();
+}
+
+class _ExampleSliderState extends State<ExampleSlider> {
+  double sliderVal = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return Slider(
+        value: sliderVal,
+        activeColor: Colors.white,
+        inactiveColor: Colors.red,
+        onChanged: (val) {
+          setState(() {
+            sliderVal = val;
+          });
+        });
   }
 }

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: Demonstrates how to use the liquid_swipe plugin.
 publish_to: 'none'
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   flutter:

--- a/lib/PageHelpers/page_dragger.dart
+++ b/lib/PageHelpers/page_dragger.dart
@@ -3,12 +3,22 @@ import 'package:liquid_swipe/Helpers/Helpers.dart';
 import 'package:liquid_swipe/Helpers/SlideUpdate.dart';
 import 'package:liquid_swipe/Provider/LiquidProvider.dart';
 import 'package:provider/provider.dart';
+import 'page_reveal.dart';
 
 /// Internal Widget
 ///
 /// PageDragger is a Widget that handles user gestures and provide the data to the [LiquidProvider]
 /// from where we perform animations various other methods.
 class PageDragger extends StatefulWidget {
+  final double horizontalReveal;
+  final Widget child;
+  final SlideDirection? slideDirection;
+  final Size iconSize;
+  final WaveType waveType;
+  final double verticalReveal;
+  final bool enableSideReveal;
+  final bool allowDragOnlyFromRevealedArea;
+
   /// Used to make animation faster or slower through it corresponding value
   /// default : [FULL_TRANSITION_PX]
   final double fullTransitionPX;
@@ -24,6 +34,14 @@ class PageDragger extends StatefulWidget {
 
   ///Constructor with some default values
   PageDragger({
+    required this.horizontalReveal,
+    required this.child,
+    this.slideDirection,
+    required this.iconSize,
+    required this.waveType,
+    required this.verticalReveal,
+    required this.enableSideReveal,
+    required this.allowDragOnlyFromRevealedArea,
     this.fullTransitionPX = FULL_TRANSITION_PX,
     this.slideIconWidget,
     this.iconPosition,
@@ -131,29 +149,77 @@ class _PageDraggerState extends State<PageDragger> {
     final model = Provider.of<LiquidProvider>(context, listen: false);
 
     return GestureDetector(
-        behavior: HitTestBehavior.translucent,
-        onHorizontalDragStart: model.isInProgress ? null : onDragStart,
-        onHorizontalDragUpdate: model.isInProgress ? null : onDragUpdate,
-        onHorizontalDragEnd: model.isInProgress ? null : onDragEnd,
-        child: Align(
-          alignment: Alignment(
-            1 - slidePercentHor,
-            -1.0 + Utils.handleIconAlignment(widget.iconPosition!) * 2,
-          ),
-          child: Opacity(
-            opacity: 1 - slidePercentHor,
-            child: slideDirection != SlideDirection.leftToRight &&
-                    widget.slideIconWidget != null
-                ? SizedBox(
-                    key: _keyIcon,
-                    child: Padding(
-                      padding: const EdgeInsets.symmetric(
-                          horizontal: 2.0, vertical: 10.0),
-                      child: widget.slideIconWidget,
-                    ),
-                  )
-                : null,
-          ),
+        behavior: widget.allowDragOnlyFromRevealedArea
+            ? HitTestBehavior.translucent
+            : null,
+        onHorizontalDragStart: widget.allowDragOnlyFromRevealedArea
+            ? model.isInProgress
+                ? null
+                : onDragStart
+            : null,
+        onHorizontalDragUpdate: widget.allowDragOnlyFromRevealedArea
+            ? model.isInProgress
+                ? null
+                : onDragUpdate
+            : null,
+        onHorizontalDragEnd: widget.allowDragOnlyFromRevealedArea
+            ? model.isInProgress
+                ? null
+                : onDragEnd
+            : null,
+        child: Stack(
+          children: [
+            PageReveal(
+              //next page reveal
+              horizontalReveal: widget.horizontalReveal,
+              slideDirection: widget.slideDirection,
+              iconSize: widget.iconSize,
+              waveType: widget.waveType,
+              verticalReveal: widget.verticalReveal,
+              enableSideReveal: widget.enableSideReveal,
+              child: widget.child,
+            ),
+            GestureDetector(
+              behavior: !widget.allowDragOnlyFromRevealedArea
+                  ? HitTestBehavior.translucent
+                  : null,
+              onHorizontalDragStart: !widget.allowDragOnlyFromRevealedArea
+                  ? model.isInProgress
+                      ? null
+                      : onDragStart
+                  : null,
+              onHorizontalDragUpdate: !widget.allowDragOnlyFromRevealedArea
+                  ? model.isInProgress
+                      ? null
+                      : onDragUpdate
+                  : null,
+              onHorizontalDragEnd: !widget.allowDragOnlyFromRevealedArea
+                  ? model.isInProgress
+                      ? null
+                      : onDragEnd
+                  : null,
+              child: Align(
+                alignment: Alignment(
+                  1 - slidePercentHor,
+                  -1.0 + Utils.handleIconAlignment(widget.iconPosition!) * 2,
+                ),
+                child: Opacity(
+                  opacity: 1 - slidePercentHor,
+                  child: slideDirection != SlideDirection.leftToRight &&
+                          widget.slideIconWidget != null
+                      ? SizedBox(
+                          key: _keyIcon,
+                          child: Padding(
+                            padding: const EdgeInsets.symmetric(
+                                horizontal: 2.0, vertical: 10.0),
+                            child: widget.slideIconWidget,
+                          ),
+                        )
+                      : null,
+                ),
+              ),
+            ),
+          ],
         ));
   }
 }

--- a/lib/PageHelpers/page_dragger.dart
+++ b/lib/PageHelpers/page_dragger.dart
@@ -17,7 +17,7 @@ class PageDragger extends StatefulWidget {
   final WaveType waveType;
   final double verticalReveal;
   final bool enableSideReveal;
-  final bool allowDragOnlyFromRevealedArea;
+  final bool preferDragFromRevealedArea;
 
   /// Used to make animation faster or slower through it corresponding value
   /// default : [FULL_TRANSITION_PX]
@@ -41,7 +41,7 @@ class PageDragger extends StatefulWidget {
     required this.waveType,
     required this.verticalReveal,
     required this.enableSideReveal,
-    required this.allowDragOnlyFromRevealedArea,
+    required this.preferDragFromRevealedArea,
     this.fullTransitionPX = FULL_TRANSITION_PX,
     this.slideIconWidget,
     this.iconPosition,
@@ -149,20 +149,20 @@ class _PageDraggerState extends State<PageDragger> {
     final model = Provider.of<LiquidProvider>(context, listen: false);
 
     return GestureDetector(
-        behavior: widget.allowDragOnlyFromRevealedArea
+        behavior: widget.preferDragFromRevealedArea
             ? HitTestBehavior.translucent
             : null,
-        onHorizontalDragStart: widget.allowDragOnlyFromRevealedArea
+        onHorizontalDragStart: widget.preferDragFromRevealedArea
             ? model.isInProgress
                 ? null
                 : onDragStart
             : null,
-        onHorizontalDragUpdate: widget.allowDragOnlyFromRevealedArea
+        onHorizontalDragUpdate: widget.preferDragFromRevealedArea
             ? model.isInProgress
                 ? null
                 : onDragUpdate
             : null,
-        onHorizontalDragEnd: widget.allowDragOnlyFromRevealedArea
+        onHorizontalDragEnd: widget.preferDragFromRevealedArea
             ? model.isInProgress
                 ? null
                 : onDragEnd
@@ -180,20 +180,20 @@ class _PageDraggerState extends State<PageDragger> {
               child: widget.child,
             ),
             GestureDetector(
-              behavior: !widget.allowDragOnlyFromRevealedArea
+              behavior: !widget.preferDragFromRevealedArea
                   ? HitTestBehavior.translucent
                   : null,
-              onHorizontalDragStart: !widget.allowDragOnlyFromRevealedArea
+              onHorizontalDragStart: !widget.preferDragFromRevealedArea
                   ? model.isInProgress
                       ? null
                       : onDragStart
                   : null,
-              onHorizontalDragUpdate: !widget.allowDragOnlyFromRevealedArea
+              onHorizontalDragUpdate: !widget.preferDragFromRevealedArea
                   ? model.isInProgress
                       ? null
                       : onDragUpdate
                   : null,
-              onHorizontalDragEnd: !widget.allowDragOnlyFromRevealedArea
+              onHorizontalDragEnd: !widget.preferDragFromRevealedArea
                   ? model.isInProgress
                       ? null
                       : onDragEnd

--- a/lib/liquid_swipe.dart
+++ b/lib/liquid_swipe.dart
@@ -4,7 +4,6 @@ import 'package:liquid_swipe/Helpers/Helpers.dart';
 import 'package:liquid_swipe/Helpers/LiquidSwipeChildDelegate.dart';
 import 'package:liquid_swipe/PageHelpers/LiquidController.dart';
 import 'package:liquid_swipe/PageHelpers/page_dragger.dart';
-import 'package:liquid_swipe/PageHelpers/page_reveal.dart';
 import 'package:liquid_swipe/Provider/LiquidProvider.dart';
 import 'package:provider/provider.dart';
 
@@ -175,6 +174,19 @@ class LiquidSwipe extends StatefulWidget {
   ///see [SlidePercentCallback]
   final SlidePercentCallback? slidePercentCallback;
 
+  ///Required a bool value for disabling drag from the whole page and
+  /// allowing only from the revealed part of the screen and the icon
+  ///
+  /// Set this to true if facing problems in giving gesture controls to
+  /// the pages
+  ///
+  /// Refer to:
+  ///
+  /// https://github.com/iamSahdeep/liquid_swipe_flutter/issues/85
+  ///
+  /// https://github.com/iamSahdeep/liquid_swipe_flutter/issues/83
+  final bool allowDragOnlyFromRevealedArea;
+
   ///Required a bool value for disabling Fast Animation between pages
   ///
   /// If true fast swiping is disabled
@@ -248,6 +260,7 @@ class LiquidSwipe extends StatefulWidget {
     this.onPageChangeCallback,
     this.currentUpdateTypeCallback,
     this.slidePercentCallback,
+    this.allowDragOnlyFromRevealedArea = false,
     this.ignoreUserGestureWhileAnimating = false,
     this.disableUserGesture = false,
     this.enableSideReveal = false,
@@ -311,6 +324,7 @@ class LiquidSwipe extends StatefulWidget {
     this.onPageChangeCallback,
     this.currentUpdateTypeCallback,
     this.slidePercentCallback,
+    this.allowDragOnlyFromRevealedArea = false,
     this.ignoreUserGestureWhileAnimating = false,
     this.disableUserGesture = false,
     this.enableSideReveal = false,
@@ -363,28 +377,26 @@ class _LiquidSwipe extends State<LiquidSwipe> with TickerProviderStateMixin {
                 : widget.liquidSwipeChildDelegate
                     .getChildAtIndex(context, notifier.nextPageIndex),
             //Pages
-            PageReveal(
-              //next page reveal
+            PageDragger(
+              //Used for gesture control
               horizontalReveal: notifier.slidePercentHor,
-              child: notifier.slideDirection == SlideDirection.leftToRight
-                  ? widget.liquidSwipeChildDelegate
-                      .getChildAtIndex(context, notifier.nextPageIndex)
-                  : widget.liquidSwipeChildDelegate
-                      .getChildAtIndex(context, notifier.activePageIndex),
               slideDirection: notifier.slideDirection,
               iconSize: notifier.iconSize,
               waveType: widget.waveType,
               verticalReveal: notifier.slidePercentVer,
               enableSideReveal: notifier.enableSideReveal,
-            ),
-            PageDragger(
-              //Used for gesture control
+              allowDragOnlyFromRevealedArea: widget.allowDragOnlyFromRevealedArea,
               fullTransitionPX: widget.fullTransitionValue,
               slideIconWidget: widget.slideIconWidget,
               iconPosition: widget.positionSlideIcon,
               ignoreUserGestureWhileAnimating:
                   widget.ignoreUserGestureWhileAnimating,
-            ), //PageDragger
+              child: notifier.slideDirection == SlideDirection.leftToRight
+                  ? widget.liquidSwipeChildDelegate
+                      .getChildAtIndex(context, notifier.nextPageIndex)
+                  : widget.liquidSwipeChildDelegate
+                      .getChildAtIndex(context, notifier.activePageIndex),
+            ),
           ], //Widget//Stack
         );
       }),

--- a/lib/liquid_swipe.dart
+++ b/lib/liquid_swipe.dart
@@ -278,43 +278,45 @@ class LiquidSwipe extends StatefulWidget {
 
   ///A builder constructor with same fields but with [itemBuilder]
   ///Sample itembuilder :
-  ///
-  ///               itemCount: data.length,
-  ///               itemBuilder: (context, index){
-  ///                 return Container(
-  ///                   color: data[index].color,
-  ///                   child: Column(
-  ///                     crossAxisAlignment: CrossAxisAlignment.center,
-  ///                     mainAxisSize: MainAxisSize.max,
-  ///                     mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-  ///                     children: <Widget>[
-  ///                       Image.asset(
-  ///                         data[index].image,
-  ///                         fit: BoxFit.cover,
-  ///                       ),
-  ///                       Padding(
-  ///                         padding: EdgeInsets.all(20.0),
-  ///                       ),
-  ///                       Column(
-  ///                         children: <Widget>[
-  ///                           Text(
-  ///                             data[index].text1,
-  ///                             style: WithPages.style,
-  ///                           ),
-  ///                           Text(
-  ///                             data[index].text2,
-  ///                             style: WithPages.style,
-  ///                           ),
-  ///                           Text(
-  ///                             data[index].text3,
-  ///                             style: WithPages.style,
-  ///                           ),
-  ///                         ],
-  ///                       ),
-  ///                     ],
-  ///                   ),
-  ///                 );
-  ///               },
+  ///```dart
+  /// LiquidSwipe.builder(
+  ///   itemCount: data.length,
+  ///   itemBuilder: (context, index){
+  ///   return Container(
+  ///     color: data[index].color,
+  ///     child: Column(
+  ///       crossAxisAlignment: CrossAxisAlignment.center,
+  ///       mainAxisSize: MainAxisSize.max,
+  ///       mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+  ///       children: <Widget>[
+  ///         Image.asset(
+  ///           data[index].image,
+  ///           fit: BoxFit.cover,
+  ///         ),
+  ///         Padding(
+  ///           padding: EdgeInsets.all(20.0),
+  ///         ),
+  ///         Column(
+  ///           children: <Widget>[
+  ///             Text(
+  ///               data[index].text1,
+  ///               style: WithPages.style,
+  ///             ),
+  ///             Text(
+  ///               data[index].text2,
+  ///               style: WithPages.style,
+  ///             ),
+  ///             Text(
+  ///               data[index].text3,
+  ///               style: WithPages.style,
+  ///             ),
+  ///           ],
+  ///         ),
+  ///       ],
+  ///      ),
+  ///   );}
+  /// ),
+  ///```
   ///
   /// See Example for complete reference.
   LiquidSwipe.builder({

--- a/lib/liquid_swipe.dart
+++ b/lib/liquid_swipe.dart
@@ -174,18 +174,25 @@ class LiquidSwipe extends StatefulWidget {
   ///see [SlidePercentCallback]
   final SlidePercentCallback? slidePercentCallback;
 
-  ///Required a bool value for disabling drag from the whole page and
-  /// allowing only from the revealed part of the screen and the icon
+  ///Required a bool value to prefer disabling the drag from the whole page and
+  /// allowing only from the revealed part of the screen and the icon.
   ///
-  /// Set this to true if facing problems in giving gesture controls to
-  /// the pages
+  /// When set to true, it will ignore any gesture arenas inside the container pages
+  /// allowing them to work properly. However the page will still be draggable from non
+  /// gesture arenas.
   ///
+  /// At least one of the [slideIconWidget] or [enableSideReveal] must be there
+  /// for this to work.
+  ///
+  /// Set this to true if facing problems in giving gesture controls inside the pages
+  ///
+  /// ----
   /// Refer to:
   ///
-  /// https://github.com/iamSahdeep/liquid_swipe_flutter/issues/85
+  /// * https://github.com/iamSahdeep/liquid_swipe_flutter/issues/85
   ///
-  /// https://github.com/iamSahdeep/liquid_swipe_flutter/issues/83
-  final bool allowDragOnlyFromRevealedArea;
+  /// * https://github.com/iamSahdeep/liquid_swipe_flutter/issues/83
+  final bool preferDragFromRevealedArea;
 
   ///Required a bool value for disabling Fast Animation between pages
   ///
@@ -260,7 +267,7 @@ class LiquidSwipe extends StatefulWidget {
     this.onPageChangeCallback,
     this.currentUpdateTypeCallback,
     this.slidePercentCallback,
-    this.allowDragOnlyFromRevealedArea = false,
+    this.preferDragFromRevealedArea = false,
     this.ignoreUserGestureWhileAnimating = false,
     this.disableUserGesture = false,
     this.enableSideReveal = false,
@@ -324,7 +331,7 @@ class LiquidSwipe extends StatefulWidget {
     this.onPageChangeCallback,
     this.currentUpdateTypeCallback,
     this.slidePercentCallback,
-    this.allowDragOnlyFromRevealedArea = false,
+    this.preferDragFromRevealedArea = false,
     this.ignoreUserGestureWhileAnimating = false,
     this.disableUserGesture = false,
     this.enableSideReveal = false,
@@ -385,7 +392,7 @@ class _LiquidSwipe extends State<LiquidSwipe> with TickerProviderStateMixin {
               waveType: widget.waveType,
               verticalReveal: notifier.slidePercentVer,
               enableSideReveal: notifier.enableSideReveal,
-              allowDragOnlyFromRevealedArea: widget.allowDragOnlyFromRevealedArea,
+              preferDragFromRevealedArea: widget.preferDragFromRevealedArea,
               fullTransitionPX: widget.fullTransitionValue,
               slideIconWidget: widget.slideIconWidget,
               iconPosition: widget.positionSlideIcon,


### PR DESCRIPTION
Fixed issues #83 and #85 by adding new parameter `allowDragOnlyFromRevealedArea` to `LiquidSwipe` class which is by default false, and so doesn't change any behavior of the package's present version unless the user chooses to enable it. Basically what is changed is that when the parameter is set to true, the drag will only work from the revealed page area and not from the whole page, which was overwriting any horizontal gestures given to the pages within the `LiquidSwipe`. So users, if faces any kind of problems with giving gestures inside the pages can now enable it to fix the issue.